### PR TITLE
Use ci-container

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -24,6 +24,9 @@ on:
 jobs:
   e2e:
     runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/vdaas/vald/vald-ci-container:nightly
+      options: "--add-host host.docker.internal:host-gateway"
     steps:
       - uses: actions/checkout@v3
       - uses: vdaas/vald-client-ci/.github/actions/e2e@main

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ node_modules
 
 /coverage
 /tests/wordvecs1000.json
+/Makefile.d/k3d.mk

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ node_modules
 
 /coverage
 /tests/wordvecs1000.json
-/Makefile.d/k3d.mk

--- a/Makefile
+++ b/Makefile
@@ -298,13 +298,14 @@ $(BUF_GEN_PATH):
 version/node:
 	@echo $(NODE_VERSION)
 
-# K3D_MAKEFILE_URL=https://raw.githubusercontent.com/vdaas/vald/main/Makefile.d/k3d.mk
-# K3D_MAKEFILE=Makefile.d/k3d.mk
-#
-# Makefile.d:
-# 	mkdir -p Makefile.d
-#
-# $(K3D_MAKEFILE): Makefile.d
-# 	curl -fsSLo $(K3D_MAKEFILE) $(K3D_MAKEFILE_URL)
-#
-# include $(K3D_MAKEFILE)
+
+K3D_MAKEFILE_URL=https://raw.githubusercontent.com/vdaas/vald/main/Makefile.d/k3d.mk
+K3D_MAKEFILE=Makefile.d/k3d.mk
+
+Makefile.d:
+	mkdir -p Makefile.d
+
+$(K3D_MAKEFILE): Makefile.d
+	curl -fsSLo $(K3D_MAKEFILE) $(K3D_MAKEFILE_URL)
+
+include $(K3D_MAKEFILE)

--- a/Makefile
+++ b/Makefile
@@ -298,7 +298,6 @@ $(BUF_GEN_PATH):
 version/node:
 	@echo $(NODE_VERSION)
 
-
 K3D_MAKEFILE_URL=https://raw.githubusercontent.com/vdaas/vald/main/Makefile.d/k3d.mk
 K3D_MAKEFILE=Makefile.d/k3d.mk
 

--- a/Makefile
+++ b/Makefile
@@ -304,6 +304,13 @@ K3D_MAKEFILE=Makefile.d/k3d.mk
 Makefile.d:
 	mkdir -p Makefile.d
 
+sync/k3d/mk: \
+	remove/k3d/mk
+	$(K3D_MAKEFILE)
+
+remove/k3d/mk:
+	rm -rf $(K3D_MAKEFILE)
+
 $(K3D_MAKEFILE): Makefile.d
 	@curl -fsSLo $(K3D_MAKEFILE) $(K3D_MAKEFILE_URL)
 

--- a/Makefile
+++ b/Makefile
@@ -306,6 +306,6 @@ Makefile.d:
 	mkdir -p Makefile.d
 
 $(K3D_MAKEFILE): Makefile.d
-	curl -fsSLo $(K3D_MAKEFILE) $(K3D_MAKEFILE_URL)
+	@curl -fsSLo $(K3D_MAKEFILE) $(K3D_MAKEFILE_URL)
 
 include $(K3D_MAKEFILE)

--- a/Makefile
+++ b/Makefile
@@ -298,7 +298,6 @@ $(BUF_GEN_PATH):
 version/node:
 	@echo $(NODE_VERSION)
 
-
 K3D_MAKEFILE_URL=https://raw.githubusercontent.com/vdaas/vald/main/Makefile.d/k3d.mk
 K3D_MAKEFILE=Makefile.d/k3d.mk
 
@@ -306,6 +305,6 @@ Makefile.d:
 	mkdir -p Makefile.d
 
 $(K3D_MAKEFILE): Makefile.d
-    curl -fsSLo $(K3D_MAKEFILE) $(K3D_MAKEFILE_URL)
+	curl -fsSLo $(K3D_MAKEFILE) $(K3D_MAKEFILE_URL)
 
 include $(K3D_MAKEFILE)

--- a/Makefile
+++ b/Makefile
@@ -298,13 +298,13 @@ $(BUF_GEN_PATH):
 version/node:
 	@echo $(NODE_VERSION)
 
-K3D_MAKEFILE_URL=https://raw.githubusercontent.com/vdaas/vald/main/Makefile.d/k3d.mk
-K3D_MAKEFILE=Makefile.d/k3d.mk
-
-Makefile.d:
-	mkdir -p Makefile.d
-
-$(K3D_MAKEFILE): Makefile.d
-	curl -fsSLo $(K3D_MAKEFILE) $(K3D_MAKEFILE_URL)
-
-include $(K3D_MAKEFILE)
+# K3D_MAKEFILE_URL=https://raw.githubusercontent.com/vdaas/vald/main/Makefile.d/k3d.mk
+# K3D_MAKEFILE=Makefile.d/k3d.mk
+#
+# Makefile.d:
+# 	mkdir -p Makefile.d
+#
+# $(K3D_MAKEFILE): Makefile.d
+# 	curl -fsSLo $(K3D_MAKEFILE) $(K3D_MAKEFILE_URL)
+#
+# include $(K3D_MAKEFILE)

--- a/Makefile
+++ b/Makefile
@@ -297,3 +297,15 @@ $(BUF_GEN_PATH):
 ## Print Node version
 version/node:
 	@echo $(NODE_VERSION)
+
+
+K3D_MAKEFILE_URL=https://raw.githubusercontent.com/vdaas/vald/main/Makefile.d/k3d.mk
+K3D_MAKEFILE=Makefile.d/k3d.mk
+
+Makefile.d:
+	mkdir -p Makefile.d
+
+$(K3D_MAKEFILE): Makefile.d
+    curl -fsSLo $(K3D_MAKEFILE) $(K3D_MAKEFILE_URL)
+
+include $(K3D_MAKEFILE)

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,9 @@ VALD_SHA    = VALD_SHA
 VALD_CLIENT_NODE_VERSION = VALD_CLIENT_NODE_VERSION
 VALD_CHECKOUT_REF ?= main
 
+K3D_MAKEFILE_URL=https://raw.githubusercontent.com/vdaas/vald/main/Makefile.d/k3d.mk
+K3D_MAKEFILE=Makefile.d/k3d.mk
+
 PWD    := $(eval PWD := $(shell pwd))$(PWD)
 
 PROTO_ROOT  = $(VALD_DIR)/apis/proto
@@ -297,9 +300,6 @@ $(BUF_GEN_PATH):
 ## Print Node version
 version/node:
 	@echo $(NODE_VERSION)
-
-K3D_MAKEFILE_URL=https://raw.githubusercontent.com/vdaas/vald/main/Makefile.d/k3d.mk
-K3D_MAKEFILE=Makefile.d/k3d.mk
 
 Makefile.d:
 	mkdir -p Makefile.d

--- a/Makefile
+++ b/Makefile
@@ -272,7 +272,7 @@ ci/deps/install:
 
 .PHONY: ci/deps/update
 ## update deps for CI environment
-ci/deps/update:
+ci/deps/update: sync/k3d/mk
 	npm update
 
 .PHONY: ci/package/prepare
@@ -304,14 +304,8 @@ K3D_MAKEFILE=Makefile.d/k3d.mk
 Makefile.d:
 	mkdir -p Makefile.d
 
-sync/k3d/mk: \
-	remove/k3d/mk
-	$(K3D_MAKEFILE)
-
-remove/k3d/mk:
+sync/k3d/mk: Makefile.d
 	rm -rf $(K3D_MAKEFILE)
-
-$(K3D_MAKEFILE): Makefile.d
-	@curl -fsSLo $(K3D_MAKEFILE) $(K3D_MAKEFILE_URL)
+	curl -fsSLo $(K3D_MAKEFILE) $(K3D_MAKEFILE_URL)
 
 include $(K3D_MAKEFILE)

--- a/Makefile.d/k3d.mk
+++ b/Makefile.d/k3d.mk
@@ -1,0 +1,68 @@
+#
+# Copyright (C) 2019-2024 vdaas.org vald team <vald@vdaas.org>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# You may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+K3D_CLUSTER_NAME  = "vald-cluster"
+K3D_COMMAND       = k3d
+K3D_NODES         = 5
+K3D_PORT          = 6550
+K3D_HOST          = localhost
+K3D_INGRESS_PORT  = 8081
+K3D_HOST_PID_MODE = true
+K3D_OPTIONS       = --port $(K3D_INGRESS_PORT):80@loadbalancer
+
+.PHONY: k3d/install
+## install K3D
+k3d/install: $(BINDIR)/k3d
+
+$(BINDIR)/k3d:
+	mkdir -p $(BINDIR)
+	curl -fsSL https://raw.githubusercontent.com/k3d-io/k3d/main/install.sh | bash
+	chmod a+x $(BINDIR)/$(K3D_COMMAND)
+
+.PHONY: k3d/start
+## start k3d (kubernetes in docker) cluster
+k3d/start:
+	$(K3D_COMMAND) cluster create $(K3D_CLUSTER_NAME) \
+	  --agents $(K3D_NODES) \
+	  --image docker.io/rancher/k3s:$(K3S_VERSION) \
+	  --host-pid-mode=$(K3D_HOST_PID_MODE) \
+	  --api-port $(K3D_HOST):$(K3D_PORT) \
+	  -v "/lib/modules:/lib/modules" \
+	  $(K3D_OPTIONS)
+	@make k3d/config
+
+.PHONY: k3d/storage
+## storage k3d (kubernetes in docker) cluster
+k3d/storage:
+	kubectl apply -f https://raw.githubusercontent.com/rancher/local-path-provisioner/master/deploy/local-path-storage.yaml
+	kubectl get storageclass
+	kubectl patch storageclass local-path -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+
+.PHONY: k3d/config
+## config k3d (kubernetes in docker) cluster
+k3d/config:
+	export KUBECONFIG="$(shell $(K3D_COMMAND) kubeconfig merge -o $(TEMP_DIR)/k3d_$(K3D_CLUSTER_NAME)_kubeconfig.yaml $(K3D_CLUSTER_NAME) --kubeconfig-switch-context)"
+
+.PHONY: k3d/restart
+## restart k3d (kubernetes in docker) cluster
+k3d/restart: \
+	k3d/delete \
+	k3d/start
+
+.PHONY: k3d/delete
+## stop k3d (kubernetes in docker) cluster
+k3d/delete:
+	-$(K3D_COMMAND) cluster delete $(K3D_CLUSTER_NAME)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Enhanced the end-to-end testing workflow by specifying a Docker container for improved integration and network configuration.
	- Updated the `.gitignore` to exclude a generated K3D makefile, keeping the repository clean.
	- Improved the build system by integrating an external K3D makefile, enhancing modularity and maintainability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->